### PR TITLE
feat: add reverse click behavior setting for HUD share button

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -248,6 +248,10 @@
         "name": "Configure User Blacklist",
         "hint": "Exclude specific users from receiving shared media.",
         "description": "Check the boxes next to users you want to exclude from receiving shared media."
+      },
+      "reverseClickBehavior": {
+        "name": "Reverse Click Behavior",
+        "hint": "Swap the actions of the HUD share button. When enabled, left click shares the actor image and right click shares the token art. When disabled, left click shares the token art and right click shares the actor image."
       }
     }
   },

--- a/scripts/common/const.mjs
+++ b/scripts/common/const.mjs
@@ -68,6 +68,7 @@ export const MODULE_SETTINGS = {
   mediaSidebarSettings: "mediaSidebarSettings",
   entitySharingSettings: "entitySharingSettings",
   blacklistSettings: "blacklistSettings",
+  reverseClickBehavior: "reverseClickBehavior",
 };
 
 /* -------------------------------------------- */

--- a/scripts/settings/settings.mjs
+++ b/scripts/settings/settings.mjs
@@ -83,6 +83,8 @@ const registerSettings = () => {
     scope: CONST.SETTING_SCOPES.CLIENT,
     type: Boolean,
     default: false,
+    name: "share-media.settings.reverseClickBehavior.name",
+    hint: "share-media.settings.reverseClickBehavior.hint",
   });
 };
 

--- a/scripts/settings/settings.mjs
+++ b/scripts/settings/settings.mjs
@@ -77,6 +77,13 @@ const registerSettings = () => {
     scope: CONST.SETTING_SCOPES.WORLD,
     type: new ArrayField(new StringField(), { initial: [], gmOnly: true }),
   });
+
+  game.settings.register("share-media", settings.reverseClickBehavior, {
+    config: true,
+    scope: CONST.SETTING_SCOPES.CLIENT,
+    type: Boolean,
+    default: false,
+  });
 };
 
 /* -------------------------------------------- */

--- a/scripts/shareables/_module.mjs
+++ b/scripts/shareables/_module.mjs
@@ -143,8 +143,17 @@ export const registerEntitySharingActions = () => {
 
         // Add the click handler to the button
         button.addEventListener("click", () => {
-          options.src = application.object.document.texture.src;
-          if (config.caption) options.settings.caption = application.object.document.name;
+          const reverse = game.settings.get(
+            "share-media",
+            CONFIG.shareMedia.CONST.MODULE_SETTINGS.reverseClickBehavior,
+          );
+          if (reverse && application.object[baseName]) {
+            options.src = application.object[baseName].img;
+            if (config.caption) options.settings.caption = application.object[baseName].name;
+          } else {
+            options.src = application.object.document.texture.src;
+            if (config.caption) options.settings.caption = application.object.document.name;
+          }
           new game.modules.shareMedia.shareables.apps.shareSelector(options).render({
             force: true,
           });
@@ -153,8 +162,17 @@ export const registerEntitySharingActions = () => {
         // Add the right click handler to the button
         if (application.object[baseName]) {
           button.addEventListener("contextmenu", () => {
-            options.src = application.object[baseName].img;
-            if (config.caption) options.settings.caption = application.object[baseName].name;
+            const reverse = game.settings.get(
+              "share-media",
+              CONFIG.shareMedia.CONST.MODULE_SETTINGS.reverseClickBehavior,
+            );
+            if (reverse) {
+              options.src = application.object.document.texture.src;
+              if (config.caption) options.settings.caption = application.object.document.name;
+            } else {
+              options.src = application.object[baseName].img;
+              if (config.caption) options.settings.caption = application.object[baseName].name;
+            }
             new game.modules.shareMedia.shareables.apps.shareSelector(options).render({
               force: true,
             });


### PR DESCRIPTION
## Summary

The HUD share button currently has fixed actions: left click shares the token art, right click shares the linked actor image. This adds a client setting (**Reverse Click Behavior**, default off) that swaps them.

| Setting | Left click | Right click |
|---------|-----------|-------------|
| **Off** (default) | Token art | Actor image |
| **On** | Actor image | Token art |

The setting appears in the standard module settings under Share Media → Configure Settings. It is client-scoped, so each GM can pick their preference.

## Change

- `scripts/common/const.mjs` — added `reverseClickBehavior` to `MODULE_SETTINGS`
- `scripts/settings/settings.mjs` — registered a client-scoped boolean setting, default `false`
- `scripts/shareables/_module.mjs` — the HUD button handlers now read the setting and swap which source each action shares. The right-click (actor image) handler only existed when the token had a linked actor; that condition is preserved, and when reverse mode is on the right click still shares the token art (which always exists)
- `languages/en.json` — label and hint for the new setting

## Notes

- No migration needed: a new setting with a default value.
- Existing world data is unaffected; the setting defaults to the current behavior.
